### PR TITLE
Reduce dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Add the following dependencies to your ```pom.xml``` file:
         <dependency>
              <groupId>org.jboss.aerogear</groupId>
              <artifactId>unifiedpush-java-client</artifactId>
-             <version>0.4.0</version>
+             <version>0.6.0-SNAPSHOT</version>
         </dependency>
 
-        <!-- RestEasy's Jackson Plugin -->
+        <!-- Jackson2 -->
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
-            <version>2.3.2.Final</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.3.1</version>
         </dependency>
 
 ## Usage

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,9 @@
             <version>2.3.8</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
-            <version>2.3.2.Final</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.3.1</version>
             <scope>provided</scope>
         </dependency>
         <!-- TEST dependencies -->

--- a/src/main/java/org/jboss/aerogear/unifiedpush/SenderClient.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/SenderClient.java
@@ -17,8 +17,9 @@
 package org.jboss.aerogear.unifiedpush;
 
 import static org.jboss.aerogear.unifiedpush.utils.ValidationUtils.isEmpty;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import net.iharder.Base64;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.jboss.aerogear.unifiedpush.message.MessageResponseCallback;
 import org.jboss.aerogear.unifiedpush.message.UnifiedMessage;
 import java.io.IOException;


### PR DESCRIPTION
Since we don't use the RestEasy client API, it's bogus to include all of it's Jackson(1) dependencies.

Instead, we really just require the `databinding` facility of Jackson, hence using latest release here.
