### PR TITLE
Removing RestEasy dependency and adding jackson.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.8.5</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.3.0</version>
         </dependency>
 
         <!-- TEST dependencies -->

--- a/src/main/java/org/jboss/aerogear/unifiedpush/SenderClient.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/SenderClient.java
@@ -17,9 +17,10 @@
 package org.jboss.aerogear.unifiedpush;
 
 import static org.jboss.aerogear.unifiedpush.utils.ValidationUtils.isEmpty;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import net.iharder.Base64;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.jboss.aerogear.unifiedpush.http.HttpClient;
 import org.jboss.aerogear.unifiedpush.message.MessageResponseCallback;
 import org.jboss.aerogear.unifiedpush.message.UnifiedMessage;
@@ -38,6 +39,7 @@ public class SenderClient implements JavaSender {
     private static final Logger logger = Logger.getLogger(SenderClient.class.getName());
 
     private static final Charset UTF_8 = Charset.forName("UTF-8");
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private String serverURL;
     private ProxyConfig proxy;
@@ -293,10 +295,9 @@ public class SenderClient implements JavaSender {
      * A simple utility to transforms an {@link Object} into a json {@link String}
      */
     private String toJSONString(Object value) {
-        ObjectMapper om = new ObjectMapper();
         String stringPayload = null;
         try {
-            stringPayload = om.writeValueAsString(value);
+            stringPayload = OBJECT_MAPPER.writeValueAsString(value);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to encode JSON payload");
         }


### PR DESCRIPTION
As far as I can tell there are now dependencies to RestEasy in the code
base. The dependency to RestEasy was of scope provided which meant that
a project depending on this one would have to define the dependency to
jackson them selves.

Adding jackson as a compile dependency allows project using this one to
not have to add any dependencies.
