### PR TITLE
Remove redundant version declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.3.0</version>
         </dependency>
 
         <!-- TEST dependencies -->


### PR DESCRIPTION
Version 2.3.0 is already defined in aerogear BOM
