### PR TITLE
AGPUSH-1262 : add windows builder methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.jboss.aerogear.unifiedpush</groupId>
             <artifactId>unifiedpush-push-model</artifactId>
-            <version>1.1.0-alpha.1</version>
+            <version>1.1.0-alpha.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedMessage.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedMessage.java
@@ -414,6 +414,17 @@ public class UnifiedMessage {
             }
 
             /**
+             * Set the raw notification type. A raw notification is a type of push notification without any associated UI.
+             * <a href="https://msdn.microsoft.com/en-us/library/windows/apps/hh761463.aspx">more info about the raw type</a>
+             *
+             * @return the current {@link WindowsBuilder} instance
+             */
+            public WindowsBuilder raw() {
+                windows.setType(Type.raw);
+                return this;
+            }
+
+            /**
              * Set the badge notifications type for badges that are not numbers,
              * for numbers use {@link MessageBuilder#badge(String)} method.
              * Check the <a href="https://msdn.microsoft.com/en-us/library/windows/apps/hh761494.aspx">Tile and badge catalog</a>

--- a/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedMessage.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedMessage.java
@@ -255,7 +255,7 @@ public class UnifiedMessage {
 
         private final Builder builder;
         private final Message message = new Message();
-        private  WindowsBuilder windowsBuilder;
+        private WindowsBuilder windowsBuilder;
 
         /**
          * Triggers a dialog, displaying the value.
@@ -486,9 +486,9 @@ public class UnifiedMessage {
                 return this;
             }
 
-            public UnifiedMessage build() {
+            public MessageBuilder build() {
                 messageBuilder.message.setWindows(windows);
-                return messageBuilder.builder.build();
+                return messageBuilder;
             }
 
         }

--- a/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedMessageTest.java
+++ b/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedMessageTest.java
@@ -162,6 +162,7 @@ public class UnifiedMessageTest {
                 .badge("5")
                 .windows()
                     .badgeType(BadgeType.busy)
+                    .build()
                 .build();
         assertEquals(Type.badge, unifiedMessage.getMessage().getObject().getWindows().getType());
         assertEquals(BadgeType.busy, unifiedMessage.getMessage().getObject().getWindows().getBadge());
@@ -171,9 +172,10 @@ public class UnifiedMessageTest {
     public void windowsTileMessage() {
         UnifiedMessage unifiedMessage = UnifiedMessage.withMessage()
                 .windows()
-                .tileType(TileType.TileSquarePeekImageAndText01)
-                .textFields(Arrays.asList("bob","alice"))
-                .images(Arrays.asList("img/bob.png","img/alice.png"))
+                 .tileType(TileType.TileSquarePeekImageAndText01)
+                 .textFields(Arrays.asList("bob","alice"))
+                 .images(Arrays.asList("img/bob.png","img/alice.png"))
+                 .build()
                 .build();
         assertEquals(Type.tile, unifiedMessage.getMessage().getObject().getWindows().getType());
         assertEquals(TileType.TileSquarePeekImageAndText01, unifiedMessage.getMessage().getObject().getWindows().getTileType());
@@ -185,7 +187,8 @@ public class UnifiedMessageTest {
     public void windowsToastMessage() {
         UnifiedMessage unifiedMessage = UnifiedMessage.withMessage()
                 .windows()
-                .toastType(ToastType.ToastText01)
+                 .toastType(ToastType.ToastText01)
+                 .build()
                 .build();
         assertEquals(Type.toast, unifiedMessage.getMessage().getObject().getWindows().getType());
         assertEquals(ToastType.ToastText01, unifiedMessage.getMessage().getObject().getWindows().getToastType());
@@ -195,7 +198,8 @@ public class UnifiedMessageTest {
     public void windowsRawMessage() {
         UnifiedMessage unifiedMessage = UnifiedMessage.withMessage()
                 .windows()
-                .type(Type.raw)
+                 .type(Type.raw)
+                 .build()
                 .build();
         assertEquals(Type.raw, unifiedMessage.getMessage().getObject().getWindows().getType());
     }

--- a/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedMessageTest.java
+++ b/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedMessageTest.java
@@ -16,6 +16,10 @@
  */
 package org.jboss.aerogear.unifiedpush.message;
 
+import org.jboss.aerogear.unifiedpush.message.windows.BadgeType;
+import org.jboss.aerogear.unifiedpush.message.windows.TileType;
+import org.jboss.aerogear.unifiedpush.message.windows.ToastType;
+import org.jboss.aerogear.unifiedpush.message.windows.Type;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -24,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
@@ -149,4 +154,51 @@ public class UnifiedMessageTest {
         assertEquals("foo-value", ((Map) unifiedMessage.getMessage().getObject().getUserData()).get("foo-key"));
         assertEquals("bar-value", ((Map) unifiedMessage.getMessage().getObject().getUserData()).get("bar-key"));
     }
+
+    @Test
+    public void windowsBadgeMessage() {
+
+        UnifiedMessage unifiedMessage = UnifiedMessage.withMessage()
+                .badge("5")
+                .windows()
+                    .badgeType(BadgeType.busy)
+                .build();
+        assertEquals(Type.badge, unifiedMessage.getMessage().getObject().getWindows().getType());
+        assertEquals(BadgeType.busy, unifiedMessage.getMessage().getObject().getWindows().getBadge());
+    }
+
+    @Test
+    public void windowsTileMessage() {
+        UnifiedMessage unifiedMessage = UnifiedMessage.withMessage()
+                .windows()
+                .tileType(TileType.TileSquarePeekImageAndText01)
+                .textFields(Arrays.asList("bob","alice"))
+                .images(Arrays.asList("img/bob.png","img/alice.png"))
+                .build();
+        assertEquals(Type.tile, unifiedMessage.getMessage().getObject().getWindows().getType());
+        assertEquals(TileType.TileSquarePeekImageAndText01, unifiedMessage.getMessage().getObject().getWindows().getTileType());
+        assertEquals(2, unifiedMessage.getMessage().getObject().getWindows().getTextFields().size());
+        assertEquals(2,unifiedMessage.getMessage().getObject().getWindows().getImages().size());
+    }
+
+    @Test
+    public void windowsToastMessage() {
+        UnifiedMessage unifiedMessage = UnifiedMessage.withMessage()
+                .windows()
+                .toastType(ToastType.ToastText01)
+                .build();
+        assertEquals(Type.toast, unifiedMessage.getMessage().getObject().getWindows().getType());
+        assertEquals(ToastType.ToastText01, unifiedMessage.getMessage().getObject().getWindows().getToastType());
+    }
+
+    @Test
+    public void windowsRawMessage() {
+        UnifiedMessage unifiedMessage = UnifiedMessage.withMessage()
+                .windows()
+                .type(Type.raw)
+                .build();
+        assertEquals(Type.raw, unifiedMessage.getMessage().getObject().getWindows().getType());
+    }
+
+
 }

--- a/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedMessageTest.java
+++ b/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedMessageTest.java
@@ -198,7 +198,7 @@ public class UnifiedMessageTest {
     public void windowsRawMessage() {
         UnifiedMessage unifiedMessage = UnifiedMessage.withMessage()
                 .windows()
-                 .type(Type.raw)
+                 .raw()
                  .build()
                 .build();
         assertEquals(Type.raw, unifiedMessage.getMessage().getObject().getWindows().getType());


### PR DESCRIPTION
This is a first version of Windows support for the Java Sender. This should be merged only after the UPS alpha.2 release (tha'ts why the pom.xml is for now modified to enable testing).

Please take a close look at the new API methods, the test case can be a good start.
I'm not sure about the `build()` method of the `WindowsBuilder` , it builds and return the `UnifiedPushMessage` but maybe it should return the `MessageBuilder` instead since it's a "sub"-builder, wdyt ? 

@edewit @secondsun could you take a look ? 