### PR TITLE
Text plain

### DIFF
--- a/src/main/java/org/jboss/aerogear/unifiedpush/PushSender.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/PushSender.java
@@ -26,7 +26,7 @@ public interface PushSender {
     /**
      * Sends the given payload to installations of the referenced PushApplication.
      * We also pass a {@link MessageResponseCallback} to handle the message
-     * 
+     *
      * @param unifiedMessage the {@link UnifiedMessage} to send.
      * @param callback the {@link MessageResponseCallback}.
      */
@@ -34,14 +34,14 @@ public interface PushSender {
 
     /**
      * Sends the given payload to installations of the referenced PushApplication.
-     * 
+     *
      * @param unifiedMessage The {@link UnifiedMessage} to send.
      */
     void send(UnifiedMessage unifiedMessage);
 
     /**
      * Returns the current configured server URL
-     * 
+     *
      * @return the current configured server URL.
      */
     String getServerURL();

--- a/src/main/java/org/jboss/aerogear/unifiedpush/PushSenderException.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/PushSenderException.java
@@ -1,0 +1,20 @@
+package org.jboss.aerogear.unifiedpush;
+
+/**
+ * Called when Sender failed to community with UnifiedPush Sender
+ */
+public class PushSenderException extends RuntimeException {
+
+    private static final long serialVersionUID = -1946523107970810661L;
+
+    private int statusCode;
+
+    public PushSenderException(String message, int statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/src/main/java/org/jboss/aerogear/unifiedpush/http/HttpClient.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/http/HttpClient.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.security.KeyStore;
+
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -40,7 +41,7 @@ public class HttpClient {
 
     /**
      * Returns URLConnection that 'posts' the given JSON to the given UnifiedPush Server URL.
-     * 
+     *
      * @param url
      * @param encodedCredentials
      * @param jsonPayloadObject
@@ -79,7 +80,7 @@ public class HttpClient {
         ((HttpURLConnection) conn).setFixedLengthStreamingMode(bytes.length);
         conn.setRequestProperty("Authorization", "Basic " + encodedCredentials);
         conn.setRequestProperty("Content-Type", "application/json");
-        conn.setRequestProperty("Accept", "application/json");
+        conn.setRequestProperty("Accept", "application/json, text/plain");
 
         // custom header, for UPS
         conn.setRequestProperty("aerogear-sender", "AeroGear Java Sender");
@@ -100,7 +101,7 @@ public class HttpClient {
 
     /**
      * Method to open/establish a URLConnection.
-     * 
+     *
      * @param url The URL to connect to.
      * @param proxy The proxy configuration.
      * @return {@link URLConnection}

--- a/src/main/java/org/jboss/aerogear/unifiedpush/message/MessageResponseCallback.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/message/MessageResponseCallback.java
@@ -17,25 +17,25 @@
 
 package org.jboss.aerogear.unifiedpush.message;
 
+import org.jboss.aerogear.unifiedpush.PushSenderException;
+
 /**
  * A simple Callback interface used when sending {@link UnifiedMessage}
- * 
  */
 public interface MessageResponseCallback {
 
     /**
-     * Will be called whatever the response status code is. It's the developer
-     * responsibility to implement the status code handling. Please consult the
-     * <a href="http://aerogear.org/docs/specs/aerogear-unifiedpush-rest/sender/index.html/">server documentation</a>
-     * for a list of valid responses.
-     * 
+     * Will be called if response from server is successful.
+     *
      * @param statusCode the status code as returned by the server.
      */
     void onComplete(int statusCode);
 
     /**
      * Will be called if an Exception occurs (i.e : {@link java.io.IOException} )
-     * 
+     *
+     * {@link PushSenderException} is passed as a parameter when returned statusCode is erroneous.
+     *
      * @param throwable contains failure details.
      */
     void onError(Throwable throwable);


### PR DESCRIPTION
https://issues.jboss.org/browse/AGPUSH-1378

https://issues.jboss.org/browse/AGPUSH-1394

* added `text/plain` to `Accept` header
* handle errorneous status codes (>= 400) by throwing `PushSenderException`

Tested against `1.1.0-alpha.2` and `master`

You can test this by adding this test into the push client source:
https://gist.github.com/lfryc/044d39f58bd08f1adf6a

