### PR TITLE
AGPUSH-1378: Java Sender should also accept text/plain

### DIFF
--- a/src/main/java/org/jboss/aerogear/unifiedpush/http/HttpClient.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/http/HttpClient.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.security.KeyStore;
+
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -40,7 +41,7 @@ public class HttpClient {
 
     /**
      * Returns URLConnection that 'posts' the given JSON to the given UnifiedPush Server URL.
-     * 
+     *
      * @param url
      * @param encodedCredentials
      * @param jsonPayloadObject
@@ -79,7 +80,7 @@ public class HttpClient {
         ((HttpURLConnection) conn).setFixedLengthStreamingMode(bytes.length);
         conn.setRequestProperty("Authorization", "Basic " + encodedCredentials);
         conn.setRequestProperty("Content-Type", "application/json");
-        conn.setRequestProperty("Accept", "application/json");
+        conn.setRequestProperty("Accept", "application/json, text/plain");
 
         // custom header, for UPS
         conn.setRequestProperty("aerogear-sender", "AeroGear Java Sender");
@@ -100,7 +101,7 @@ public class HttpClient {
 
     /**
      * Method to open/establish a URLConnection.
-     * 
+     *
      * @param url The URL to connect to.
      * @param proxy The proxy configuration.
      * @return {@link URLConnection}


### PR DESCRIPTION
https://issues.jboss.org/browse/AGPUSH-1378

Tested with UPS `1.1.0-alpha.2` and `master`.

You can test this by adding`MyTest` into Java Sender source, updating credentials and executing it: https://gist.github.com/lfryc/044d39f58bd08f1adf6a